### PR TITLE
bug: Set ServerUrl on new clients

### DIFF
--- a/client/self_managed_waypoint_config.go
+++ b/client/self_managed_waypoint_config.go
@@ -11,9 +11,6 @@ type WaypointConfig struct {
 	///WaypointUserToken is the user token used for auth in self-managed Waypoint. Only for Self-Managed Waypoint.
 	WaypointUserToken string
 
-	// ServerURL is the URL of the Waypoint Server. Only for Self-Managed Waypoint.
-	ServerUrl string
-
 	// Waypoint by default runs with a self-signed certificate.
 	InsecureSkipVerify bool
 }
@@ -21,8 +18,11 @@ type WaypointConfig struct {
 func NewWithSelfManaged(waypointUserToken, serverUrl string, skipVerify bool) (*Config, error) {
 	waypointcfg := &WaypointConfig{
 		WaypointUserToken:  waypointUserToken,
-		ServerUrl:          serverUrl,
 		InsecureSkipVerify: skipVerify,
+	}
+
+	if serverUrl == "" {
+		return nil, fmt.Error("cannot create self managed waypoint config, no server url provided")
 	}
 
 	err := waypointcfg.validateSelfManaged()
@@ -37,10 +37,6 @@ func NewWithSelfManaged(waypointUserToken, serverUrl string, skipVerify bool) (*
 }
 
 func (c *WaypointConfig) validateSelfManaged() error {
-	if c.ServerUrl == "" {
-		return fmt.Errorf("server url must be provided")
-	}
-
 	if c.WaypointUserToken == "" {
 		return fmt.Errorf("user token must be provided")
 	}

--- a/client/self_managed_waypoint_config.go
+++ b/client/self_managed_waypoint_config.go
@@ -21,6 +21,7 @@ type WaypointConfig struct {
 func NewWithSelfManaged(waypointUserToken, serverUrl string, skipVerify bool) (*Config, error) {
 	waypointcfg := &WaypointConfig{
 		WaypointUserToken:  waypointUserToken,
+		ServerUrl:          serverUrl,
 		InsecureSkipVerify: skipVerify,
 	}
 

--- a/client/self_managed_waypoint_config.go
+++ b/client/self_managed_waypoint_config.go
@@ -22,7 +22,7 @@ func NewWithSelfManaged(waypointUserToken, serverUrl string, skipVerify bool) (*
 	}
 
 	if serverUrl == "" {
-		return nil, fmt.Error("cannot create self managed waypoint config, no server url provided")
+		return nil, fmt.Errorf("cannot create self managed waypoint config, no server url provided")
 	}
 
 	err := waypointcfg.validateSelfManaged()


### PR DESCRIPTION
Prior to this commit, the new func wouldn't set the server url for new self managed clients, so the validation would error out given that it wasn't ever set.

From my testing prior to this change:

```
panic: cannot create self managed waypoint config: server url must be provided
```

I believe this is because we don't set `ServerUrl` on the struct pointer when creating a new client.

https://github.com/hashicorp/waypoint-client/blob/bbc513c1c619e176d5477cd48faf3e73eed1f651/client/self_managed_waypoint_config.go#L39-L41